### PR TITLE
Java 8 support, cleanup and refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # ontorefine-cli
-A command-line interface for execution of operations in OntoRefine tool
+A command-line interface for execution of operations in OntoRefine
+
+    Usage: ontorefine-cli [-hV] [COMMAND]
+
+    -h, --help      Show this help message and exit.
+    -V, --version   Print version information and exit.
+
+    Commands:
+
+    create     Creates a new project from a file.
+    delete     Deletes a project from OntoRefine.
+    export     Exports the data of a project in CSV or JSON format.
+    extract    Extracts the operations of a project in JSON format.
+    apply      Applies transformation operations to a project.
+    reconcile  Performs reconciliation over the project data.
+    rdf        Converts the data of a project to RDF format.
+    help       Displays help information about the specified command

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <url>https://github.com/Ontotext-AD/ontorefine-cli</url>
     </scm>
 
-    <!-- TODO not sure that we are going to release this one here or in that 
+    <!-- TODO not sure that we are going to release this one here or in that
         matter anywhere -->
     <distributionManagement>
         <repository>
@@ -70,8 +70,8 @@
     </repositories>
 
     <properties>
-        <java.version>11</java.version>
-        <project.java.version>11</project.java.version>
+        <java.version>8</java.version>
+        <project.java.version>8</project.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <cvss.threshold>6.9</cvss.threshold>

--- a/src/main/java/com/ontotext/refine/cli/ApplyOperations.java
+++ b/src/main/java/com/ontotext/refine/cli/ApplyOperations.java
@@ -7,10 +7,9 @@ import com.ontotext.refine.client.command.RefineCommands;
 import com.ontotext.refine.client.command.operations.ApplyOperationsResponse;
 import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Parameters;
@@ -23,9 +22,8 @@ import picocli.CommandLine.Parameters;
  */
 @Command(
     name = "apply",
-    description = "Applies transformation operations to specific project.",
-    version = "1.0.0",
-    mixinStandardHelpOptions = true)
+    description = "Applies transformation operations to a project.",
+    separator = " ")
 class ApplyOperations extends Process {
 
   @Parameters(
@@ -46,7 +44,7 @@ class ApplyOperations extends Process {
   @Override
   public Integer call() throws Exception {
     try (RefineClient client = getClient()) {
-      String ops = IOUtils.toString(new FileReader(operations, StandardCharsets.UTF_8));
+      String ops = IOUtils.toString(new FileInputStream(operations), StandardCharsets.UTF_8);
 
       ApplyOperationsResponse response = RefineCommands
           .applyOperations()
@@ -58,7 +56,7 @@ class ApplyOperations extends Process {
 
       if (ResponseCode.ERROR.equals(response.getCode())) {
         String error = String.format(
-            "Failed to apply transformation to the project '%s' due to: %s",
+            "Failed to apply transformation to project '%s' due to: %s",
             project,
             response.getMessage());
 
@@ -72,14 +70,5 @@ class ApplyOperations extends Process {
       System.err.println(re.getMessage());
     }
     return ExitCode.SOFTWARE;
-  }
-
-  /**
-   * Runs the apply operations command.
-   *
-   * @param args to pass to the process
-   */
-  public static void main(String[] args) {
-    System.exit(new CommandLine(new ApplyOperations()).execute(args));
   }
 }

--- a/src/main/java/com/ontotext/refine/cli/ConvertRdf.java
+++ b/src/main/java/com/ontotext/refine/cli/ConvertRdf.java
@@ -6,28 +6,26 @@ import com.ontotext.refine.client.command.RefineCommands;
 import com.ontotext.refine.client.command.operations.GetOperationsResponse;
 import com.ontotext.refine.client.command.rdf.ExportRdfResponse;
 import com.ontotext.refine.client.exceptions.RefineException;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Parameters;
 
 
 /**
- * Defines the export RDF process and all of the required arguments for it.
+ * Defines the convert RDF process and all of the required arguments for it.
  *
  * @author Antoniy Kunchev
  */
 @Command(
-    name = "exportRdf",
-    description = "Exports the data of specified project in RDF format.",
-    version = "1.0.0",
-    mixinStandardHelpOptions = true)
-class ExportRdf extends Process {
+    name = "rdf",
+    description = "Converts the data of a project to RDF format.",
+    separator = " ")
+class ConvertRdf extends Process {
 
   @Parameters(
       index = "0",
       paramLabel = "PROJECT",
-      description = "The project which data should be exported.")
+      description = "The project whose data to convert.")
   private String project;
 
   // TODO add mapping as parameter, if missing then try to retrieve one from the operations
@@ -49,7 +47,8 @@ class ExportRdf extends Process {
       System.err.println(re.getMessage());
     } catch (Exception exc) {
       String error = String.format(
-          "Failed to execute RDF export for project: '%s' due to %s", project, exc.getMessage());
+          "Failed to execute RDF conversion for project: '%s' due to %s", project,
+          exc.getMessage());
       System.err.println(error);
     }
     return ExitCode.SOFTWARE;
@@ -67,14 +66,5 @@ class ExportRdf extends Process {
     }
 
     return mapping;
-  }
-
-  /**
-   * Runs the export RDF process.
-   *
-   * @param args to pass to the process
-   */
-  public static void main(String[] args) {
-    System.exit(new CommandLine(new ExportRdf()).execute(args));
   }
 }

--- a/src/main/java/com/ontotext/refine/cli/CreateProject.java
+++ b/src/main/java/com/ontotext/refine/cli/CreateProject.java
@@ -7,7 +7,6 @@ import com.ontotext.refine.client.command.create.CreateProjectResponse;
 import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.File;
 import org.apache.commons.lang3.StringUtils;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Option;
@@ -22,20 +21,20 @@ import picocli.CommandLine.Parameters;
 @Command(
     name = "create",
     description = "Creates a new project from a file.",
-    version = "1.0.0",
-    mixinStandardHelpOptions = true)
+    separator = " ")
 class CreateProject extends Process {
 
   @Parameters(
       index = "0",
       paramLabel = "FILE",
-      description = "The file which will be used to create the project."
-          + " It should be full name with extension (csv, tsv, xml, json, txt, xls, xlsx, ods).")
+      description = "The file that will be used to create the project."
+          + " It should be a full name with one of the supported extensions"
+          + " (csv, tsv, xml, json, txt, xls, xlsx, ods).")
   private File file;
 
   @Option(
       names = {"-n", "--name"},
-      description = "The name with which the project will be created. If not provided,"
+      description = "The name of the OntoRefine project to create. If not provided,"
           + " the file name will be used.")
   private String name;
 
@@ -65,14 +64,5 @@ class CreateProject extends Process {
       System.err.println(re.getMessage());
     }
     return ExitCode.SOFTWARE;
-  }
-
-  /**
-   * Runs the creation of project command.
-   *
-   * @param args to pass to the process
-   */
-  public static void main(String[] args) {
-    System.exit(new CommandLine(new CreateProject()).execute(args));
   }
 }

--- a/src/main/java/com/ontotext/refine/cli/DeleteProject.java
+++ b/src/main/java/com/ontotext/refine/cli/DeleteProject.java
@@ -5,7 +5,6 @@ import com.ontotext.refine.client.ResponseCode;
 import com.ontotext.refine.client.command.RefineCommands;
 import com.ontotext.refine.client.command.delete.DeleteProjectResponse;
 import com.ontotext.refine.client.exceptions.RefineException;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Parameters;
@@ -18,15 +17,14 @@ import picocli.CommandLine.Parameters;
  */
 @Command(
     name = "delete",
-    description = "Deletes specific project from OntoRefine.",
-    version = "1.0.0",
-    mixinStandardHelpOptions = true)
+    description = "Deletes a project from OntoRefine.",
+    separator = " ")
 class DeleteProject extends Process {
 
   @Parameters(
       index = "0",
       paramLabel = "PROJECT",
-      description = "The identifier of the project which should be deleted.")
+      description = "The identifier of the project to delete.")
   private String project;
 
   @Override
@@ -53,14 +51,5 @@ class DeleteProject extends Process {
       System.err.println(re.getMessage());
     }
     return ExitCode.SOFTWARE;
-  }
-
-  /**
-   * Runs the deletion of project command.
-   *
-   * @param args to pass to the process
-   */
-  public static void main(String[] args) {
-    System.exit(new CommandLine(new DeleteProject()).execute(args));
   }
 }

--- a/src/main/java/com/ontotext/refine/cli/Export.java
+++ b/src/main/java/com/ontotext/refine/cli/Export.java
@@ -7,7 +7,6 @@ import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FileUtils;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Parameters;
@@ -20,21 +19,20 @@ import picocli.CommandLine.Parameters;
  */
 @Command(
     name = "export",
-    description = "Exports the data of specified project in specific format.",
-    version = "1.0.0",
-    mixinStandardHelpOptions = true)
+    description = "Exports the data of a project in CSV or JSON format.",
+    separator = " ")
 class Export extends Process {
 
   @Parameters(
       index = "0",
       paramLabel = "PROJECT",
-      description = "The identifier of the project to which the data should be exported.")
+      description = "The identifier of the project to export.")
   private String project;
 
   @Parameters(
       index = "1",
       paramLabel = "FORMAT",
-      description = "The output format in which the data should be exported.")
+      description = "The output format of the export (csv or json).")
   private String format;
 
   @Override
@@ -71,14 +69,5 @@ class Export extends Process {
 
   private boolean isFormatSupported() {
     return "csv".equalsIgnoreCase(format) || "json".equalsIgnoreCase(format);
-  }
-
-  /**
-   * Runs the export command.
-   *
-   * @param args to pass to the process
-   */
-  public static void main(String[] args) {
-    System.exit(new CommandLine(new Export()).execute(args));
   }
 }

--- a/src/main/java/com/ontotext/refine/cli/ExtractOperations.java
+++ b/src/main/java/com/ontotext/refine/cli/ExtractOperations.java
@@ -4,28 +4,26 @@ import com.ontotext.refine.client.RefineClient;
 import com.ontotext.refine.client.command.RefineCommands;
 import com.ontotext.refine.client.command.operations.GetOperationsResponse;
 import com.ontotext.refine.client.exceptions.RefineException;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Parameters;
 
 
 /**
- * Defines the export operations process and all of the required arguments for it.
+ * Defines the extract operations process and all of the required arguments for it.
  *
  * @author Antoniy Kunchev
  */
 @Command(
-    name = "exportOperations",
-    description = "Exports the operations of specified project in JSON format.",
-    version = "1.0.0",
-    mixinStandardHelpOptions = true)
-class ExportOperations extends Process {
+    name = "extract",
+    description = "Extracts the operations of a project in JSON format.",
+    separator = " ")
+class ExtractOperations extends Process {
 
   @Parameters(
       index = "0",
       paramLabel = "PROJECT",
-      description = "The project which operations should be exported.")
+      description = "The project whose operations to extract.")
   private String project;
 
   @Override
@@ -41,14 +39,5 @@ class ExportOperations extends Process {
       System.err.println(re.getMessage());
     }
     return ExitCode.SOFTWARE;
-  }
-
-  /**
-   * Runs the export operation process.
-   *
-   * @param args to pass to the process
-   */
-  public static void main(String[] args) {
-    System.exit(new CommandLine(new ExportOperations()).execute(args));
   }
 }

--- a/src/main/java/com/ontotext/refine/cli/Main.java
+++ b/src/main/java/com/ontotext/refine/cli/Main.java
@@ -1,0 +1,36 @@
+package com.ontotext.refine.cli;
+
+import picocli.CommandLine;
+
+/**
+ * The main entry-point for the ontorefine-cli command. The remaining commands
+ * are defined as subcommands such that the whole appears as a single application.
+ * The order of the commands is significant and represents the likely workflow,
+ * grouped by functionality.
+ */
+@CommandLine.Command(name = "ontorefine-cli",
+    subcommands = { CreateProject.class, DeleteProject.class, Export.class,
+      ExtractOperations.class, ApplyOperations.class, Reconcile.class, ConvertRdf.class,
+      RetrieveVersion.class, CommandLine.HelpCommand.class },
+    mixinStandardHelpOptions = true,
+    separator = " ",
+    versionProvider = VersionProvider.class)
+class Main implements Runnable {
+  @Override
+  public void run() {
+    // won't be called, this command has subcommands
+  }
+
+  public static void main(String... args) {
+    final CommandLine cmd = new CommandLine(new Main());
+
+    if (args.length > 0) {
+      System.exit(cmd.execute(args));
+    } else {
+      // No arguments, complain and show usage
+      System.err.println("Missing command.");
+      cmd.usage(System.err);
+      System.exit(CommandLine.ExitCode.USAGE);
+    }
+  }
+}

--- a/src/main/java/com/ontotext/refine/cli/Process.java
+++ b/src/main/java/com/ontotext/refine/cli/Process.java
@@ -21,11 +21,10 @@ abstract class Process implements Callable<Integer> {
   private RefineClient client;
 
   @Option(
-      names = {"-u", "--uri"},
-      description = "The URI to the OntoRefine instance."
-          + " It should include the protocol, host, port and context path if needed.",
+      names = {"-u", "--url"},
+      description = "The URL of the GraphDB instance whose OntoRefine to connect to, e.g. http://localhost:7200.",
       required = true)
-  private String uri;
+  private String url;
 
   /**
    * Creates {@link RefineClient} instance and caches it in order to be reused if there are
@@ -37,7 +36,7 @@ abstract class Process implements Callable<Integer> {
   protected RefineClient getClient() throws RefineException {
     if (client == null) {
       try {
-        client = RefineClients.create(uri);
+        client = RefineClients.create(url);
       } catch (Exception exc) {
         throw new RefineException("Failed to get client instance due to: " + exc.getMessage());
       }

--- a/src/main/java/com/ontotext/refine/cli/Reconcile.java
+++ b/src/main/java/com/ontotext/refine/cli/Reconcile.java
@@ -11,7 +11,6 @@ import com.ontotext.refine.client.command.reconcile.ReconcileCommand.ColumnType;
 import com.ontotext.refine.client.command.reconcile.ReconcileCommandResponse;
 import com.ontotext.refine.client.exceptions.RefineException;
 import java.util.Collection;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Option;
@@ -26,8 +25,7 @@ import picocli.CommandLine.Parameters;
 @Command(
     name = "reconcile",
     description = "Performs reconciliation over the project data.",
-    version = "1.0.0",
-    mixinStandardHelpOptions = true)
+    separator = " ")
 class Reconcile extends Process {
 
   private static final int SLEEP_T = 2000;
@@ -36,14 +34,14 @@ class Reconcile extends Process {
       index = "0",
       arity = "1",
       paramLabel = "PROJECT",
-      description = "The identifier of the project which should be reconciled.")
+      description = "The identifier of the project whose data to reconcile.")
   private String project;
 
   @Parameters(
       index = "1",
       arity = "1",
       paramLabel = "COLUMN",
-      description = "The identifier of the column that should be reconciled.")
+      description = "The identifier of the column to reconcile.")
   private String column;
 
   @Parameters(
@@ -55,7 +53,7 @@ class Reconcile extends Process {
 
   @Option(
       names = {"-a", "--async"},
-      description = "Whether to execute the operation asynchronous and output the progress.",
+      description = "Whether to execute the operation asynchronously and output the progress.",
       defaultValue = "false")
   private Boolean async;
 
@@ -172,14 +170,5 @@ class Reconcile extends Process {
         .setToken(getToken())
         .build()
         .execute(client);
-  }
-
-  /**
-   * Runs the reconcile operation process.
-   *
-   * @param args to pass to the process
-   */
-  public static void main(String[] args) {
-    System.exit(new CommandLine(new Reconcile()).execute(args));
   }
 }

--- a/src/main/java/com/ontotext/refine/cli/RetrieveVersion.java
+++ b/src/main/java/com/ontotext/refine/cli/RetrieveVersion.java
@@ -4,7 +4,6 @@ import com.ontotext.refine.client.RefineClient;
 import com.ontotext.refine.client.command.RefineCommands;
 import com.ontotext.refine.client.command.version.GetVersionResponse;
 import com.ontotext.refine.client.exceptions.RefineException;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;
 
@@ -17,8 +16,8 @@ import picocli.CommandLine.ExitCode;
 @Command(
     name = "version",
     description = "Retrieves the version of the OntoRefine instance.",
-    version = "1.0.0",
-    mixinStandardHelpOptions = true)
+    separator = " ",
+    hidden = true)
 class RetrieveVersion extends Process {
 
   @Override
@@ -35,14 +34,5 @@ class RetrieveVersion extends Process {
       System.err.println(re.getMessage());
     }
     return ExitCode.SOFTWARE;
-  }
-
-  /**
-   * Runs the version retrieval process.
-   *
-   * @param args to be passed to the process
-   */
-  public static void main(String[] args) {
-    System.exit(new CommandLine(new RetrieveVersion()).execute(args));
   }
 }

--- a/src/main/java/com/ontotext/refine/cli/VersionProvider.java
+++ b/src/main/java/com/ontotext/refine/cli/VersionProvider.java
@@ -1,0 +1,28 @@
+package com.ontotext.refine.cli;
+
+import java.io.InputStream;
+import java.util.Properties;
+import picocli.CommandLine;
+
+/**
+ * Retrieves the version of the client from the packaged pom.properties file,
+ * or Unknown version if the file was not found.
+ */
+public class VersionProvider implements CommandLine.IVersionProvider {
+  @Override
+  public String[] getVersion() throws Exception {
+    try (InputStream is = VersionProvider.class.getResourceAsStream(
+        "/META-INF/maven/com.ontotext/ontorefine-cli/pom.properties")) {
+      if (is != null) {
+        Properties properties = new Properties();
+        properties.load(is);
+        String version = properties.getProperty("version");
+        if (version != null) {
+          return new String[] { "OntoRefine-CLI v" + version };
+        }
+      }
+    }
+
+    return new String[] { "OntoRefine-CLI Unknown version" };
+  }
+}

--- a/src/test/java/com/ontotext/refine/cli/ApplyOperationsTest.java
+++ b/src/test/java/com/ontotext/refine/cli/ApplyOperationsTest.java
@@ -43,8 +43,8 @@ class ApplyOperationsTest extends BaseProcessTest {
   }
 
   @Override
-  protected Consumer<String[]> commandExecutor() {
-    return ApplyOperations::main;
+  protected Class<?> command() {
+    return ApplyOperations.class;
   }
 
   @Test
@@ -102,7 +102,7 @@ class ApplyOperationsTest extends BaseProcessTest {
 
       String error = consoleErrors().split(System.lineSeparator())[0];
       assertEquals(
-          "Failed to apply transformation to the project '1812661014997' due to: Failed!", error);
+          "Failed to apply transformation to project '1812661014997' due to: Failed!", error);
     }
   }
 

--- a/src/test/java/com/ontotext/refine/cli/ConvertRdfTest.java
+++ b/src/test/java/com/ontotext/refine/cli/ConvertRdfTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 import org.apache.http.HttpStatus;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.entity.ContentType;
@@ -20,11 +19,11 @@ import picocli.CommandLine.ExitCode;
 
 
 /**
- * Test for {@link ExportRdf}.
+ * Test for {@link ConvertRdf}.
  *
  * @author Antoniy Kunchev
  */
-class ExportRdfTest extends BaseProcessTest {
+class ConvertRdfTest extends BaseProcessTest {
 
   private static RefineResponder responder = new RefineResponder();
   private static boolean shouldFailOperationsExtraction;
@@ -41,8 +40,8 @@ class ExportRdfTest extends BaseProcessTest {
   }
 
   @Override
-  protected Consumer<String[]> commandExecutor() {
-    return ExportRdf::main;
+  protected Class<?> command() {
+    return ConvertRdf.class;
   }
 
   @Test
@@ -68,7 +67,7 @@ class ExportRdfTest extends BaseProcessTest {
       assertEquals(
           "Failed to retrieve the operations for project: '1812661014997' due to:"
               + " Unexpected response : HTTP/1.1 500 Internal Server Error",
-          consoleErrors().stripTrailing());
+          consoleErrors().trim());
     }
   }
 
@@ -101,7 +100,7 @@ class ExportRdfTest extends BaseProcessTest {
         response.setStatusCode(HttpStatus.SC_OK);
         BasicHttpEntity entity = new BasicHttpEntity();
         InputStream stream =
-            ExportRdfTest.class.getClassLoader().getResourceAsStream("operations.json");
+            ConvertRdfTest.class.getClassLoader().getResourceAsStream("operations.json");
         entity.setContent(stream);
         entity.setContentType(ContentType.APPLICATION_JSON.getMimeType());
         response.setEntity(entity);
@@ -114,7 +113,7 @@ class ExportRdfTest extends BaseProcessTest {
       response.setStatusCode(HttpStatus.SC_OK);
       BasicHttpEntity entity = new BasicHttpEntity();
       InputStream stream =
-          ExportRdfTest.class.getClassLoader().getResourceAsStream("exportedRdf.ttl");
+          ConvertRdfTest.class.getClassLoader().getResourceAsStream("exportedRdf.ttl");
       entity.setContent(stream);
       response.setEntity(entity);
     };

--- a/src/test/java/com/ontotext/refine/cli/CreateProjectTest.java
+++ b/src/test/java/com/ontotext/refine/cli/CreateProjectTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 import org.apache.http.HttpStatus;
 import org.apache.http.protocol.HttpRequestHandler;
 import org.junit.jupiter.api.AfterAll;
@@ -39,8 +38,8 @@ class CreateProjectTest extends BaseProcessTest {
   }
 
   @Override
-  protected Consumer<String[]> commandExecutor() {
-    return CreateProject::main;
+  protected Class<?> command() {
+    return CreateProject.class;
   }
 
   @Test
@@ -87,7 +86,7 @@ class CreateProjectTest extends BaseProcessTest {
 
       assertEquals(
           "The project with id '1812661014997' was created successfully.",
-          consoleOutput().stripTrailing());
+          consoleOutput().trim());
     }
   }
 

--- a/src/test/java/com/ontotext/refine/cli/DeleteProjectTest.java
+++ b/src/test/java/com/ontotext/refine/cli/DeleteProjectTest.java
@@ -8,7 +8,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 import org.apache.http.HttpStatus;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.protocol.HttpRequestHandler;
@@ -42,8 +41,8 @@ class DeleteProjectTest extends BaseProcessTest {
   }
 
   @Override
-  protected Consumer<String[]> commandExecutor() {
-    return DeleteProject::main;
+  protected Class<?> command() {
+    return DeleteProject.class;
   }
 
   @Test
@@ -96,7 +95,7 @@ class DeleteProjectTest extends BaseProcessTest {
       commandExecutor().accept(args(PROJECT_ID, "-u " + responder.getUri()));
     } finally {
       assertEquals(
-          "Successfully deleted project with id: '1812661014997'", consoleOutput().stripTrailing());
+          "Successfully deleted project with id: '1812661014997'", consoleOutput().trim());
     }
   }
 

--- a/src/test/java/com/ontotext/refine/cli/ExpectSystemExit.java
+++ b/src/test/java/com/ontotext/refine/cli/ExpectSystemExit.java
@@ -74,8 +74,12 @@ public @interface ExpectSystemExit {
     }
 
     private Optional<ExpectSystemExit> getAnnotation(ExtensionContext context) {
-      return findAnnotation(context.getTestMethod(), ExpectSystemExit.class)
-          .or(() -> findAnnotation(context.getTestClass(), ExpectSystemExit.class));
+      Optional<ExpectSystemExit> opt = findAnnotation(context.getTestMethod(),
+          ExpectSystemExit.class);
+      if (!opt.isPresent()) {
+        opt = findAnnotation(context.getTestClass(), ExpectSystemExit.class);
+      }
+      return opt;
     }
 
     @Override

--- a/src/test/java/com/ontotext/refine/cli/ExportTest.java
+++ b/src/test/java/com/ontotext/refine/cli/ExportTest.java
@@ -8,7 +8,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 import org.apache.http.HttpStatus;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.protocol.HttpRequestHandler;
@@ -40,8 +39,8 @@ class ExportTest extends BaseProcessTest {
   }
 
   @Override
-  protected Consumer<String[]> commandExecutor() {
-    return Export::main;
+  protected Class<?> command() {
+    return Export.class;
   }
 
   @Test
@@ -72,7 +71,7 @@ class ExportTest extends BaseProcessTest {
     } finally {
       assertEquals(
           "The format: 'xml' is currently not supported.",
-          consoleErrors().stripTrailing());
+          consoleErrors().trim());
     }
   }
 
@@ -88,7 +87,7 @@ class ExportTest extends BaseProcessTest {
 
       assertEquals(
           "Failed to export data for project: '1812661014997' due to: 'Connection reset'",
-          consoleErrors().stripTrailing());
+          consoleErrors().trim());
     }
   }
 
@@ -101,7 +100,7 @@ class ExportTest extends BaseProcessTest {
       String errors = consoleErrors();
       assertTrue(errors.isEmpty(), "Expected no errors but there were: " + errors);
 
-      assertEquals("CSV-content", consoleOutput().stripTrailing());
+      assertEquals("CSV-content", consoleOutput().trim());
     }
   }
 

--- a/src/test/java/com/ontotext/refine/cli/ExtractOperationsTest.java
+++ b/src/test/java/com/ontotext/refine/cli/ExtractOperationsTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
-import java.util.function.Consumer;
 import org.apache.http.HttpStatus;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.entity.ContentType;
@@ -20,11 +19,11 @@ import picocli.CommandLine.ExitCode;
 
 
 /**
- * Test for {@link ExportOperations}.
+ * Test for {@link ExtractOperations}.
  *
  * @author Antoniy Kunchev
  */
-class ExportOperationsTest extends BaseProcessTest {
+class ExtractOperationsTest extends BaseProcessTest {
 
   private static RefineResponder responder = new RefineResponder();
   private static boolean shouldFailExportRequest;
@@ -41,8 +40,8 @@ class ExportOperationsTest extends BaseProcessTest {
   }
 
   @Override
-  protected Consumer<String[]> commandExecutor() {
-    return ExportOperations::main;
+  protected Class<?> command() {
+    return ExtractOperations.class;
   }
 
   @Test
@@ -68,7 +67,7 @@ class ExportOperationsTest extends BaseProcessTest {
       assertEquals(
           "Failed to retrieve the operations for project: '1812661014997' due to:"
               + " Unexpected response : HTTP/1.1 500 Internal Server Error",
-          consoleErrors().stripTrailing());
+          consoleErrors().trim());
     }
   }
 
@@ -97,7 +96,7 @@ class ExportOperationsTest extends BaseProcessTest {
         response.setStatusCode(HttpStatus.SC_OK);
         BasicHttpEntity entity = new BasicHttpEntity();
         InputStream stream =
-            ExportOperationsTest.class.getClassLoader().getResourceAsStream("operations.json");
+            ExtractOperationsTest.class.getClassLoader().getResourceAsStream("operations.json");
         entity.setContent(stream);
         entity.setContentType(ContentType.APPLICATION_JSON.getMimeType());
         response.setEntity(entity);

--- a/src/test/java/com/ontotext/refine/cli/MainTest.java
+++ b/src/test/java/com/ontotext/refine/cli/MainTest.java
@@ -1,0 +1,61 @@
+package com.ontotext.refine.cli;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+/**
+ * Created by Pavel Mihaylov on 21/09/2021.
+ */
+class MainTest extends BaseProcessTest {
+  @Override
+  protected Class<?> command() {
+    return null;
+  }
+
+  @Override
+  // Test not applicable to main command
+  protected void shouldFailOnMissingRefineUrl() {
+  }
+
+  @Test
+  @ExpectSystemExit(CommandLine.ExitCode.USAGE)
+  void shouldShowMissingCommandUsage() {
+    try {
+      commandExecutor().accept(args());
+    } finally {
+      consoleOut.println(consoleErrors());
+      assertTrue(consoleErrors().contains("Missing command."));
+      assertTrue(consoleErrors().contains("Usage: ontorefine-cli [-hV] [COMMAND]"));
+      assertTrue(consoleOutput().isEmpty());
+    }
+  }
+
+  @Test
+  @ExpectSystemExit(CommandLine.ExitCode.OK)
+  void shouldShowUsageOnHyphenH() {
+    try {
+      commandExecutor().accept(args("-h"));
+    } finally {
+      consoleOut.println(consoleOutput());
+      assertFalse(consoleOutput().contains("Missing command."));
+      assertTrue(consoleOutput().contains("Usage: ontorefine-cli [-hV] [COMMAND]"));
+      assertTrue(consoleErrors().isEmpty());
+    }
+  }
+
+  @Test
+  @ExpectSystemExit(CommandLine.ExitCode.OK)
+  void shouldShowUsageOnHelp() {
+    try {
+      commandExecutor().accept(args("-h"));
+    } finally {
+      consoleOut.println(consoleOutput());
+      assertFalse(consoleOutput().contains("Missing command."));
+      assertTrue(consoleOutput().contains("Usage: ontorefine-cli [-hV] [COMMAND]"));
+      assertTrue(consoleErrors().isEmpty());
+    }
+  }
+}

--- a/src/test/java/com/ontotext/refine/cli/ReconcileTest.java
+++ b/src/test/java/com/ontotext/refine/cli/ReconcileTest.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.function.Consumer;
 import org.apache.http.HttpStatus;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.protocol.HttpRequestHandler;
@@ -55,8 +54,8 @@ class ReconcileTest extends BaseProcessTest {
   }
 
   @Override
-  protected Consumer<String[]> commandExecutor() {
-    return Reconcile::main;
+  protected Class<?> command() {
+    return Reconcile.class;
   }
 
   @Test
@@ -170,7 +169,7 @@ class ReconcileTest extends BaseProcessTest {
 
       String expected = String.format(
           "Failed to guess the type of the column: '%s' for project: '%s'", COLUMN, PROJECT_ID);
-      assertEquals(expected, consoleErrors().stripTrailing());
+      assertEquals(expected, consoleErrors().trim());
     }
   }
 
@@ -188,7 +187,7 @@ class ReconcileTest extends BaseProcessTest {
               + " due to: Guess types error.",
           COLUMN,
           PROJECT_ID);
-      assertEquals(expected, consoleErrors().stripTrailing());
+      assertEquals(expected, consoleErrors().trim());
     }
   }
 
@@ -205,7 +204,7 @@ class ReconcileTest extends BaseProcessTest {
           "Failed to reconcile column '%s' for project '%s' due to: Reconcile error.",
           COLUMN,
           PROJECT_ID);
-      assertEquals(expected, consoleErrors().stripTrailing());
+      assertEquals(expected, consoleErrors().trim());
     }
   }
 

--- a/src/test/java/com/ontotext/refine/cli/RetrieveVersionTest.java
+++ b/src/test/java/com/ontotext/refine/cli/RetrieveVersionTest.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Map;
-import java.util.function.Consumer;
 import org.apache.http.HttpStatus;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.protocol.HttpRequestHandler;
@@ -40,8 +39,8 @@ class RetrieveVersionTest extends BaseProcessTest {
   }
 
   @Override
-  protected Consumer<String[]> commandExecutor() {
-    return RetrieveVersion::main;
+  protected Class<?> command() {
+    return RetrieveVersion.class;
   }
 
   @Test
@@ -53,7 +52,7 @@ class RetrieveVersionTest extends BaseProcessTest {
       String expected =
           "Name: OpenRefine 2.6 [1]\nFull version: 2.6 [1]\nVersion: 2.6\nRevision: 1";
       String consoleOutput = consoleOutput();
-      assertEquals(expected, consoleOutput.stripTrailing());
+      assertEquals(expected, consoleOutput.trim());
     }
   }
 
@@ -69,7 +68,7 @@ class RetrieveVersionTest extends BaseProcessTest {
 
       String expected = "Failed to retrieve the version data due to: "
           + "Unexpected response : HTTP/1.1 500 Internal Server Error";
-      assertEquals(expected, consoleErrors().stripTrailing());
+      assertEquals(expected, consoleErrors().trim());
     }
   }
 


### PR DESCRIPTION
* Support for Java 8
* Renamed some commands and cleaned up their usage
* Hidden "version" command as we need to clarify what it should do or even exist
* Use space instead of equals to show parameter usage
* Reorganized structure around a main command + subcommands such that it all appears as a single application
* Read version from packaged pom.properties