### PR TITLE
Fixes the unwrapping of the RDF mapping in the conversion process

### DIFF
--- a/src/main/java/com/ontotext/refine/cli/Main.java
+++ b/src/main/java/com/ontotext/refine/cli/Main.java
@@ -23,7 +23,7 @@ class Main implements Runnable {
   }
 
   public static void main(String... args) {
-    final CommandLine cmd = new CommandLine(new Main());
+    final CommandLine cmd = new CommandLine(new Main()).setCaseInsensitiveEnumValuesAllowed(true);
 
     if (args.length > 0) {
       System.exit(cmd.execute(args));


### PR DESCRIPTION
- When the mapping is extracted from the response for the models, the
mapping object is actually double wrapped...
- Added additional arguments which exposes the parameter for the result
format. Now the user can pass different value, if the RDF data should be
returned in another format. By default the format will be `turtle`.
- Added configuration for the `CommandLine` to accept lower cased
enumeration values.
- Added several additional test cases for the RDF conversion process.