### PR TITLE
Changes the format argument for the create project command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### New
 
  - TBD
+ 
+### Breaking Changes
+
+ - The values for the `format` argument of the create project command are changed to be more user friendly. Now the user can simply pass `csv` as a value, instead
+   of `"text/line-based/*sv"`.
+ - For this version of the CLI, the create project command will work and accept only `.csv` files and data format. The other types of files and formats will be
+   gradually over the next few releases.
 
 ### Changes
 

--- a/src/test/java/com/ontotext/refine/cli/CreateProjectTest.java
+++ b/src/test/java/com/ontotext/refine/cli/CreateProjectTest.java
@@ -52,6 +52,24 @@ class CreateProjectTest extends BaseProcessTest {
   }
 
   @Test
+  @ExpectedSystemExit(ExitCode.USAGE)
+  void shouldFailForUnsupportedFormat() {
+    try {
+      URL resource = getClass().getClassLoader().getResource("Netherlands_restaurants.csv");
+
+      String uriArg = "-u " + responder.getUri();
+      commandExecutor().accept(args(resource.getPath(), "-n Restaurants", "-f tsv", uriArg));
+    } finally {
+      String[] errorsArray = consoleErrors().split(System.lineSeparator());
+      String lastLine = errorsArray[0];
+      assertEquals(
+          "Invalid value for option '--format': expected one of [CSV] (case-insensitive)"
+              + " but was 'tsv'",
+          lastLine);
+    }
+  }
+
+  @Test
   @ExpectedSystemExit(ExitCode.SOFTWARE)
   void shouldFailToGetCrsfToken() {
     try {
@@ -59,7 +77,7 @@ class CreateProjectTest extends BaseProcessTest {
       URL resource = getClass().getClassLoader().getResource("Netherlands_restaurants.csv");
 
       String uriArg = "-u " + responder.getUri();
-      commandExecutor().accept(args(resource.getPath(), "-name Restaurants", uriArg));
+      commandExecutor().accept(args(resource.getPath(), "-n Restaurants", uriArg));
     } finally {
       failCsrfRequest = false;
 
@@ -79,7 +97,7 @@ class CreateProjectTest extends BaseProcessTest {
       URL resource = getClass().getClassLoader().getResource("Netherlands_restaurants.csv");
 
       String uriArg = "-u " + responder.getUri();
-      commandExecutor().accept(args(resource.getPath(), "-name Restaurants", uriArg));
+      commandExecutor().accept(args(resource.getPath(), "-n Restaurants", "-f csv", uriArg));
     } finally {
       String errors = consoleErrors();
       assertTrue(errors.isEmpty(), "Expected no errors but there were: " + errors);


### PR DESCRIPTION
- Added few changes to the create project command related to the format
argument and the data formats that the command works with.

  Now the `--format` argument has values that are more user friendly.
The user can simple set the format by passing `csv`, instead of the
previous value that was `text/line-based/*sv`.

  The allowed format with which the create project command will work for
now is only `csv` and `.csv` files. Other types will be added in future
releases, when they are cleared from issues and properly tested.