### PR TITLE
Adds new parameter and functionality to the RDF export command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
  - Introduced new command for transformation of specific dataset to different format. In this version the command will support only transformation of CSV to RDF.
    The goal for future releases is to gradually add more types of transformations like JSON to CSV, XML to TSV, etc. Basically the only limitations are going to be
    related, to what Ontotext Refine can accept as input for the project data and in what format can that data be exported afterwards.
+ - Enhanced the `rdf` command to accept parameter for SPARQL query. The query is used for the mapping of the project data to RDF and it takes precedence, when there
+   is a mapping and a query provided.
  
 ### Breaking Changes
 
@@ -37,6 +39,7 @@
  - Exposed some of the internal classes and enumerations in order to reuse them in the composition commands like the new `transform`.
  - A lot of common logic that was extracted in utility class so that it can be reused in more commands and processes.
  - Removed couple of values from the allowed RDF result formats, because they are not supported in the Ontotext Refine at the moment.
+ - Removed the `JSON` option from the `export` command. Currently the command will support only export in default `CSV` format.
 
 ### Bug fixes
 

--- a/src/main/java/com/ontotext/refine/cli/Export.java
+++ b/src/main/java/com/ontotext/refine/cli/Export.java
@@ -1,5 +1,8 @@
 package com.ontotext.refine.cli;
 
+import static com.ontotext.refine.cli.utils.PrintUtils.error;
+import static com.ontotext.refine.cli.utils.PrintUtils.info;
+
 import com.ontotext.refine.cli.utils.ExportUtils;
 import com.ontotext.refine.client.RefineClient;
 import com.ontotext.refine.client.command.RefineCommands;
@@ -33,13 +36,14 @@ class Export extends Process {
   @Parameters(
       index = "1",
       paramLabel = "FORMAT",
-      description = "The output format of the export (csv or json).")
+      description = "The output format of the export (only csv at the moment).",
+      defaultValue = "csv")
   private String format;
 
   @Override
   public Integer call() throws Exception {
-    if (!isFormatSupported()) {
-      System.err.println(String.format("The format: '%s' is currently not supported.", format));
+    if (!"csv".equalsIgnoreCase(format)) {
+      error("The format: '%s' is currently not supported.", format);
       return ExitCode.USAGE;
     }
 
@@ -58,17 +62,13 @@ class Export extends Process {
 
       result = response.getFile();
 
-      System.out.println(FileUtils.readFileToString(result, StandardCharsets.UTF_8));
+      info(FileUtils.readFileToString(result, StandardCharsets.UTF_8));
       return ExitCode.OK;
     } catch (RefineException re) {
-      System.err.println(re.getMessage());
+      error(re.getMessage());
     } finally {
       FileUtils.deleteQuietly(result);
     }
     return ExitCode.SOFTWARE;
-  }
-
-  private boolean isFormatSupported() {
-    return "csv".equalsIgnoreCase(format) || "json".equalsIgnoreCase(format);
   }
 }

--- a/src/test/java/com/ontotext/refine/cli/ExportTest.java
+++ b/src/test/java/com/ontotext/refine/cli/ExportTest.java
@@ -15,6 +15,7 @@ import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.protocol.HttpRequestHandler;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine.ExitCode;
 
@@ -56,6 +57,8 @@ class ExportTest extends BaseProcessTest {
 
   @Test
   @ExpectedSystemExit(ExitCode.USAGE)
+  @Disabled("We removed the multiple options ATM and there is default value."
+      + " This will be changed in future versions")
   void shouldExitWithErrorOnMissingFormatArg() {
     try {
       commandExecutor().accept(args(PROJECT_ID, "-u " + responder.getUri()));

--- a/src/test/java/com/ontotext/refine/cli/export/rdf/ExportRdfTest.java
+++ b/src/test/java/com/ontotext/refine/cli/export/rdf/ExportRdfTest.java
@@ -1,5 +1,6 @@
 package com.ontotext.refine.cli.export.rdf;
 
+import static com.ontotext.refine.cli.test.support.RefineResponder.exportHandler;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -132,11 +133,30 @@ class ExportRdfTest extends BaseProcessTest {
     }
   }
 
+  @Test
+  @ExpectedSystemExit(ExitCode.OK)
+  void shouldPassSuccessfullyProvidedSparql() throws IOException {
+    try {
+      URL resource = getClass().getClassLoader().getResource("construct.sparql");
+
+      String modelArg = "-q " + resource.getPath();
+      String uriArg = "-u " + responder.getUri();
+
+      commandExecutor().accept(args(PROJECT_ID, modelArg, uriArg));
+    } finally {
+      String errors = consoleErrors();
+      assertTrue(errors.isEmpty(), "Expected no errors but there were: " + errors);
+
+      assertFalse(consoleOutput().isEmpty(), "The output should not be empty, but it was.");
+    }
+  }
+
   private static Map<String, HttpRequestHandler> mockResponses() {
-    Map<String, HttpRequestHandler> handlers = new HashMap<>(3);
+    Map<String, HttpRequestHandler> handlers = new HashMap<>(4);
     handlers.put("/orefine/command/core/get-models", getModels());
     handlers.put("/rest/rdf-mapper/rdf/ontorefine:" + PROJECT_ID, RefineResponder.exportHandler());
     handlers.put("/orefine/command/core/get-processes", RefineResponder.noProcesses());
+    handlers.put("/repositories/ontorefine:" + PROJECT_ID, exportHandler());
     return handlers;
   }
 


### PR DESCRIPTION
- Enhanced the command for RDF export to accept SPARQL query. This way
the user have the option to provide either mapping or query in order to
export the project data as RDF. The query always will take precedence in
cases, when the command is executed and to the mapping and the query is
provided.
- Removed the `JSON` option from the `export` command. At the moment it
will only support `CSV`.