### PR TITLE
Introduces explicit enum for RDF result formats with reduced options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
    related, to what Ontotext Refine can accept as input for the project data and in what format can that data be exported afterwards.
  - Enhanced the `rdf` command to accept parameter for SPARQL query. The query is used for the mapping of the project data to RDF and it takes precedence, when there
    is a mapping and a query provided.
+ - Added new Enum for allowed RDF result formats. It will allow additional filtering the allowed formats that are going to be supported by the CLI. Also provides
+   the correct message, when the format value does not match any of the allowed formats.
  
 ### Breaking Changes
 

--- a/src/main/java/com/ontotext/refine/cli/export/rdf/AllowedRdfResultFormat.java
+++ b/src/main/java/com/ontotext/refine/cli/export/rdf/AllowedRdfResultFormat.java
@@ -1,9 +1,7 @@
 package com.ontotext.refine.cli.export.rdf;
 
-import com.ontotext.refine.client.command.rdf.ResultFormat;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.Set;
 
 /**
  * Provides the values for the allowed RDF result formats and the completion candidates for the RDF
@@ -13,12 +11,10 @@ import java.util.Set;
  */
 public class AllowedRdfResultFormat implements Iterable<String> {
 
-  private static final Set<ResultFormat> UNSUPPORTED = Set.of(ResultFormat.HDT, ResultFormat.RDFA);
-
   @Override
   public Iterator<String> iterator() {
-    return Arrays.stream(ResultFormat.values())
-        .filter(value -> !UNSUPPORTED.contains(value))
+    return Arrays
+        .stream(RdfResultFormats.values())
         .map(value -> value.toString().toLowerCase())
         .iterator();
   }

--- a/src/main/java/com/ontotext/refine/cli/export/rdf/ExportRdf.java
+++ b/src/main/java/com/ontotext/refine/cli/export/rdf/ExportRdf.java
@@ -8,7 +8,6 @@ import static com.ontotext.refine.cli.utils.RdfExportUtils.export;
 import com.ontotext.refine.cli.Process;
 import com.ontotext.refine.cli.utils.RdfExportUtils.Using;
 import com.ontotext.refine.client.RefineClient;
-import com.ontotext.refine.client.command.rdf.ResultFormat;
 import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.File;
 import picocli.CommandLine.Command;
@@ -52,7 +51,7 @@ public class ExportRdf extends Process {
           + " The allowed values are: ${COMPLETION-CANDIDATES}",
       completionCandidates = AllowedRdfResultFormat.class,
       defaultValue = "turtle")
-  private ResultFormat format;
+  private RdfResultFormats format;
 
   @Override
   public Integer call() {

--- a/src/main/java/com/ontotext/refine/cli/export/rdf/RdfResultFormats.java
+++ b/src/main/java/com/ontotext/refine/cli/export/rdf/RdfResultFormats.java
@@ -1,0 +1,46 @@
+package com.ontotext.refine.cli.export.rdf;
+
+import com.ontotext.refine.client.command.rdf.ResultFormat;
+
+/**
+ * Contains values for the result format of the export RDF commands. Basically it is a proxy for the
+ * {@link ResultFormat} values with additional filtering of the formats.
+ *
+ * @author Antoniy Kunchev
+ */
+public enum RdfResultFormats {
+
+  RDFXML(ResultFormat.RDFXML),
+
+  NTRIPLES(ResultFormat.NTRIPLES),
+
+  TURTLE(ResultFormat.TURTLE),
+
+  TURTLESTAR(ResultFormat.TURTLESTAR),
+
+  N3(ResultFormat.N3),
+
+  TRIX(ResultFormat.TRIX),
+
+  TRIG(ResultFormat.TRIG),
+
+  TRIGSTAR(ResultFormat.TRIGSTAR),
+
+  BINARY(ResultFormat.BINARY),
+
+  NQUADS(ResultFormat.NQUADS),
+
+  JSONLD(ResultFormat.JSONLD),
+
+  RDFJSON(ResultFormat.RDFJSON);
+
+  private final ResultFormat format;
+
+  private RdfResultFormats(ResultFormat format) {
+    this.format = format;
+  }
+
+  public ResultFormat getFormat() {
+    return format;
+  }
+}

--- a/src/main/java/com/ontotext/refine/cli/transform/Transform.java
+++ b/src/main/java/com/ontotext/refine/cli/transform/Transform.java
@@ -11,13 +11,13 @@ import com.ontotext.refine.cli.Process;
 import com.ontotext.refine.cli.create.AllowedInputDataFormats;
 import com.ontotext.refine.cli.create.InputDataFormat;
 import com.ontotext.refine.cli.export.rdf.AllowedRdfResultFormat;
+import com.ontotext.refine.cli.export.rdf.RdfResultFormats;
 import com.ontotext.refine.cli.utils.RdfExportUtils.Using;
 import com.ontotext.refine.client.JsonOperation;
 import com.ontotext.refine.client.RefineClient;
 import com.ontotext.refine.client.ResponseCode;
 import com.ontotext.refine.client.command.RefineCommands;
 import com.ontotext.refine.client.command.operations.ApplyOperationsResponse;
-import com.ontotext.refine.client.command.rdf.ResultFormat;
 import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.File;
 import java.io.FileInputStream;
@@ -83,7 +83,7 @@ public class Transform extends Process {
           + " '${DEFAULT-VALUE}'. The allowed values are: ${COMPLETION-CANDIDATES}",
       completionCandidates = AllowedRdfResultFormat.class,
       defaultValue = "turtle")
-  private ResultFormat result;
+  private RdfResultFormats result;
 
   @Option(
       names = "--no-clean",

--- a/src/main/java/com/ontotext/refine/cli/utils/RdfExportUtils.java
+++ b/src/main/java/com/ontotext/refine/cli/utils/RdfExportUtils.java
@@ -1,10 +1,10 @@
 package com.ontotext.refine.cli.utils;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.ontotext.refine.cli.export.rdf.RdfResultFormats;
 import com.ontotext.refine.client.RefineClient;
 import com.ontotext.refine.client.command.RefineCommands;
 import com.ontotext.refine.client.command.models.GetProjectModelsResponse;
-import com.ontotext.refine.client.command.rdf.ResultFormat;
 import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.File;
 import java.io.IOException;
@@ -38,7 +38,7 @@ public class RdfExportUtils {
   public static InputStream export(
       String project,
       File mappingFile,
-      ResultFormat resultFormat,
+      RdfResultFormats resultFormat,
       Using using,
       RefineClient client)
       throws IOException {
@@ -56,13 +56,13 @@ public class RdfExportUtils {
   private static InputStream sparqlExport(
       String project,
       File mappingFile,
-      ResultFormat format,
+      RdfResultFormats format,
       RefineClient client) throws IOException {
     return RefineCommands
         .exportAsRdf()
         .setProject(project)
         .setQuery(readFile(mappingFile))
-        .setFormat(format)
+        .setFormat(format.getFormat())
         .build()
         .execute(client)
         .getResultStream();
@@ -79,14 +79,14 @@ public class RdfExportUtils {
   private static InputStream mappingExport(
       String project,
       File mappingFile,
-      ResultFormat format,
+      RdfResultFormats format,
       RefineClient client)
       throws IOException {
     return RefineCommands
         .exportRdf()
         .setProject(project)
         .setMapping(getRdfMapping(mappingFile, project, client))
-        .setFormat(format)
+        .setFormat(format.getFormat())
         .build()
         .execute(client)
         .getResultStream();


### PR DESCRIPTION
- Added new enum containing the supported RDF formats that the export
functionalities are going to allow. It has a reduced set of value and it
will help to print correct message to the user, when the provided value
is not supported.