### PR TITLE
Updates the supported commands with help option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
  - Added detailed documentation about the project. The documentation describes the project main dependencies, provides details about the different supported
    commands and more.
+ - Added `--help` option to each command. It will provide details about the command and the arguments that can be provided to it. The information is used in the
+   documentation and to keep it up-to-date, when there are changes, we've added unit tests, which will fail, when there are mismatches.
 
 
 ## Version 1.1

--- a/commands/apply.md
+++ b/commands/apply.md
@@ -1,4 +1,4 @@
-# apply
+# Apply
 
 Applies operations to a specified project data.
 

--- a/commands/create.md
+++ b/commands/create.md
@@ -1,4 +1,4 @@
-# create
+# Create
 
 Creates a refine project using given dataset.
 

--- a/commands/delete.md
+++ b/commands/delete.md
@@ -1,4 +1,4 @@
-# delete
+# Delete
 
 Deletes a specific project from Ontotext Refine workspace.
 

--- a/commands/export.md
+++ b/commands/export.md
@@ -1,4 +1,4 @@
-# export
+# Export
 
 Exports the data of a given project in CSV format.
 

--- a/commands/extract.md
+++ b/commands/extract.md
@@ -1,4 +1,4 @@
-# extract
+# Extract
 
 Extracts all of the operations that are applied on project data.
 

--- a/commands/rdf.md
+++ b/commands/rdf.md
@@ -1,4 +1,4 @@
-# rdf
+# RDF
 
 Exports the data of a given project in RDF format.
 

--- a/commands/refine-version.md
+++ b/commands/refine-version.md
@@ -1,4 +1,4 @@
-# refine-version
+# Refine-version
 
 Retrieves the current version of the Ontotext Refine.
 

--- a/commands/register-service.md
+++ b/commands/register-service.md
@@ -1,4 +1,4 @@
-# register-service
+# Register-service
 
 Registers an additional service for reconciliation that can be used in the Ontotext Refine web interface.
 

--- a/commands/transform.md
+++ b/commands/transform.md
@@ -1,4 +1,4 @@
-# transform
+# Transform
 
 Transforms a dataset into another specific format.
 

--- a/src/main/java/com/ontotext/refine/cli/ApplyOperations.java
+++ b/src/main/java/com/ontotext/refine/cli/ApplyOperations.java
@@ -23,7 +23,14 @@ import picocli.CommandLine.Parameters;
 @Command(
     name = "apply",
     description = "Applies transformation operations to a project.",
-    separator = " ")
+    separator = " ",
+    sortOptions = false,
+    headerHeading = "Usage:%n",
+    synopsisHeading = "%n",
+    descriptionHeading = "%nDescription:%n",
+    parameterListHeading = "%nParameters:%n",
+    optionListHeading = "%nOptions:%n",
+    mixinStandardHelpOptions = true)
 class ApplyOperations extends Process {
 
   @Parameters(

--- a/src/main/java/com/ontotext/refine/cli/DeleteProject.java
+++ b/src/main/java/com/ontotext/refine/cli/DeleteProject.java
@@ -16,8 +16,15 @@ import picocli.CommandLine.Parameters;
  */
 @Command(
     name = "delete",
-    description = "Deletes a project from OntoRefine.",
-    separator = " ")
+    description = "Deletes a project from Ontotext Refine.",
+    separator = " ",
+    sortOptions = false,
+    headerHeading = "Usage:%n",
+    synopsisHeading = "%n",
+    descriptionHeading = "%nDescription:%n",
+    parameterListHeading = "%nParameters:%n",
+    optionListHeading = "%nOptions:%n",
+    mixinStandardHelpOptions = true)
 class DeleteProject extends Process {
 
   @Parameters(

--- a/src/main/java/com/ontotext/refine/cli/Export.java
+++ b/src/main/java/com/ontotext/refine/cli/Export.java
@@ -23,8 +23,15 @@ import picocli.CommandLine.Parameters;
  */
 @Command(
     name = "export",
-    description = "Exports the data of a project in CSV or JSON format.",
-    separator = " ")
+    description = "Exports the data of a project in CSV format.",
+    separator = " ",
+    sortOptions = false,
+    headerHeading = "Usage:%n",
+    synopsisHeading = "%n",
+    descriptionHeading = "%nDescription:%n",
+    parameterListHeading = "%nParameters:%n",
+    optionListHeading = "%nOptions:%n",
+    mixinStandardHelpOptions = true)
 class Export extends Process {
 
   @Parameters(

--- a/src/main/java/com/ontotext/refine/cli/ExtractOperations.java
+++ b/src/main/java/com/ontotext/refine/cli/ExtractOperations.java
@@ -16,7 +16,14 @@ import picocli.CommandLine.Parameters;
 @Command(
     name = "extract",
     description = "Extracts the operations of a project in JSON format.",
-    separator = " ")
+    separator = " ",
+    sortOptions = false,
+    headerHeading = "Usage:%n",
+    synopsisHeading = "%n",
+    descriptionHeading = "%nDescription:%n",
+    parameterListHeading = "%nParameters:%n",
+    optionListHeading = "%nOptions:%n",
+    mixinStandardHelpOptions = true)
 class ExtractOperations extends Process {
 
   @Parameters(

--- a/src/main/java/com/ontotext/refine/cli/RegisterReconService.java
+++ b/src/main/java/com/ontotext/refine/cli/RegisterReconService.java
@@ -19,7 +19,14 @@ import picocli.CommandLine.Parameters;
 @Command(
     name = "register-service",
     description = "Registers an additional reconciliation service.",
-    separator = " ")
+    separator = " ",
+    sortOptions = false,
+    headerHeading = "Usage:%n",
+    synopsisHeading = "%n",
+    descriptionHeading = "%nDescription:%n",
+    parameterListHeading = "%nParameters:%n",
+    optionListHeading = "%nOptions:%n",
+    mixinStandardHelpOptions = true)
 class RegisterReconService extends Process {
 
   @Parameters(

--- a/src/main/java/com/ontotext/refine/cli/RetrieveVersion.java
+++ b/src/main/java/com/ontotext/refine/cli/RetrieveVersion.java
@@ -13,10 +13,16 @@ import picocli.CommandLine.ExitCode;
  * @author Antoniy Kunchev
  */
 @Command(
-    name = "version",
-    description = "Retrieves the version of the OntoRefine instance.",
+    name = "refine-version",
+    description = "Retrieves the version of the Ontotext Refine instance.",
     separator = " ",
-    hidden = true)
+    sortOptions = false,
+    headerHeading = "Usage:%n",
+    synopsisHeading = "%n",
+    descriptionHeading = "%nDescription:%n",
+    parameterListHeading = "%nParameters:%n",
+    optionListHeading = "%nOptions:%n",
+    mixinStandardHelpOptions = true)
 class RetrieveVersion extends Process {
 
   @Override

--- a/src/main/java/com/ontotext/refine/cli/create/CreateProject.java
+++ b/src/main/java/com/ontotext/refine/cli/create/CreateProject.java
@@ -21,7 +21,14 @@ import picocli.CommandLine.Parameters;
 @Command(
     name = "create",
     description = "Creates a new project from a file.",
-    separator = " ")
+    separator = " ",
+    sortOptions = false,
+    headerHeading = "Usage:%n",
+    synopsisHeading = "%n",
+    descriptionHeading = "%nDescription:%n",
+    parameterListHeading = "%nParameters:%n",
+    optionListHeading = "%nOptions:%n",
+    mixinStandardHelpOptions = true)
 public class CreateProject extends Process {
 
   @Parameters(

--- a/src/main/java/com/ontotext/refine/cli/export/rdf/ExportRdf.java
+++ b/src/main/java/com/ontotext/refine/cli/export/rdf/ExportRdf.java
@@ -22,8 +22,15 @@ import picocli.CommandLine.Parameters;
  */
 @Command(
     name = "rdf",
-    description = "Converts the data of a project to RDF format.",
-    separator = " ")
+    description = "Exports the data of a project to RDF format.",
+    separator = " ",
+    sortOptions = false,
+    headerHeading = "Usage:%n",
+    synopsisHeading = "%n",
+    descriptionHeading = "%nDescription:%n",
+    parameterListHeading = "%nParameters:%n",
+    optionListHeading = "%nOptions:%n",
+    mixinStandardHelpOptions = true)
 public class ExportRdf extends Process {
 
   @Parameters(

--- a/src/main/java/com/ontotext/refine/cli/transform/Transform.java
+++ b/src/main/java/com/ontotext/refine/cli/transform/Transform.java
@@ -45,7 +45,14 @@ import picocli.CommandLine.Parameters;
 @Command(
     name = "transform",
     description = "Transforms given dataset into different data format.",
-    separator = " ")
+    separator = " ",
+    sortOptions = false,
+    headerHeading = "Usage:%n",
+    synopsisHeading = "%n",
+    descriptionHeading = "%nDescription:%n",
+    parameterListHeading = "%nParameters:%n",
+    optionListHeading = "%nOptions:%n",
+    mixinStandardHelpOptions = true)
 public class Transform extends Process {
 
   @Parameters(

--- a/src/test/java/com/ontotext/refine/cli/MainTest.java
+++ b/src/test/java/com/ontotext/refine/cli/MainTest.java
@@ -21,6 +21,11 @@ class MainTest extends BaseProcessTest {
   protected void shouldFailOnMissingRefineUrl() {
     // not applicable to main command
   }
+  
+  @Override
+  protected void shouldMatchCommandHelpInDocumentation() {
+    // not applicable to main command
+  }
 
   @Test
   @ExpectedSystemExit(ExitCode.USAGE)


### PR DESCRIPTION
- Added `--help` option to all commands that the CLI currently supports.
This way the user can easily check what are the allowed parameters and
options for the individual commands.
- Added tests for the documentation of the commands in order to keep it
up-to-date, when there are changes to the commands code.