### PR TITLE
Removes N3 from the RDF result format options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
  - Added `--help` option to each command. It will provide details about the command and the arguments that can be provided to it. The information is used in the
    documentation and to keep it up-to-date, when there are changes, we've added unit tests, which will fail, when there are mismatches.
 
+### Changes
+
+ - Removed the `N3` RDF result format as an option, when exporting in RDF. `N3` is a subset of `Turtle` and the internal library used to produce the different
+   formats just writes `Turtle` for both options. This is done in order to prevent confusing moments, when the user expects different formats.
+
 
 ## Version 1.1
 

--- a/commands/rdf.md
+++ b/commands/rdf.md
@@ -32,8 +32,8 @@ Options:
                               configurations, if it is defined there.
   -f, --format <format>     Controls the format of the result. The default
                               format is 'turtle'. The allowed values are:
-                              rdfxml, ntriples, turtle, turtlestar, n3, trix,
-                              trig, trigstar, binary, nquads, jsonld, rdfjson
+                              rdfxml, ntriples, turtle, turtlestar, trix, trig,
+                              trigstar, binary, nquads, jsonld, rdfjson
   -h, --help                Show this help message and exit.
   -V, --version             Print version information and exit.
 ```

--- a/commands/transform.md
+++ b/commands/transform.md
@@ -42,8 +42,8 @@ Options:
                             for RDFization of the provided dataset.
   -r, --result <result>   Controls the output format of the result. The default
                             format is 'turtle'. The allowed values are: rdfxml,
-                            ntriples, turtle, turtlestar, n3, trix, trig,
-                            trigstar, binary, nquads, jsonld, rdfjson
+                            ntriples, turtle, turtlestar, trix, trig, trigstar,
+                            binary, nquads, jsonld, rdfjson
       --[no-]clean        Controls the cleaning of the project after the
                             operation execution. When enabled the clean up will
                             be executed regardless of the success of the

--- a/src/main/java/com/ontotext/refine/cli/export/rdf/RdfResultFormats.java
+++ b/src/main/java/com/ontotext/refine/cli/export/rdf/RdfResultFormats.java
@@ -18,8 +18,6 @@ public enum RdfResultFormats {
 
   TURTLESTAR(ResultFormat.TURTLESTAR),
 
-  N3(ResultFormat.N3),
-
   TRIX(ResultFormat.TRIX),
 
   TRIG(ResultFormat.TRIG),


### PR DESCRIPTION
- Removed the `N3` format option from the `RdfResultFormats`, because it
is a subset of `Turtule` and the internal `RDFWriter` serialize it as
`Turtle`. This will prevent any confusion in the usage and issues
reporting for unsupported types.