### PR TITLE
More upload formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Ontotext Refine CLI
 
+## Version 1.2.1
+
+### New
+
+ - Introduced additional upload formats for `create-project` and `transform` commands. Now the commands should work with more complete set of formats,
+   except CSV.
+   Although the Refine supports the formats, they are introduced in experimental state for the CLI as there are not tested extensively and there could be some
+   issues with them.
+
+### Changes
+
+ - Updated the versions of the third party dependencies to the latest available.
+
+
 ## Version 1.2
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
    except CSV.
    Although the Refine supports the formats, they are introduced in experimental state for the CLI as there are not tested extensively and there could be some
    issues with them.
+ - Added validation for the import options for some of the allowed input data formats. The `XML` and `JSON` datasets require specific import option to be
+   present during the importing process. This property is called `recordPath` and it contains set of values describing the path in which the file will be parsed
+   in order to be represented in tabular form.
+
+   The validation is needed, because of a bug in the `OpenRefine` logic, where the errors caused from the missing property are ignored and the response from the
+   project creation is OK, although in actuality there isn't any project created.
+
+   Now when the user provides invalid configurations for the import options, (s)he will receive an error notifying that the import options are wrong or missing.
+
+   This should be temporary solution, but.. yeah we all know how this goes. :)
 
 ### Changes
 

--- a/commands/create.md
+++ b/commands/create.md
@@ -19,8 +19,7 @@ Creates a new project from a file.
 Parameters:
       FILE                The file that will be used to create the project. It
                             should be a full name with one of the supported
-                            extensions (csv, tsv, json, txt, xls, xlsx, js,
-                            etc.).
+                            extensions (csv, tsv, json, xls, xlsx, etc.).
 
 Options:
   -u, --url <url>         The URL of the Ontotext Refine instance to connect

--- a/commands/create.md
+++ b/commands/create.md
@@ -19,7 +19,8 @@ Creates a new project from a file.
 Parameters:
       FILE                The file that will be used to create the project. It
                             should be a full name with one of the supported
-                            extensions (csv).
+                            extensions (csv, tsv, json, txt, xls, xlsx, js,
+                            etc.).
 
 Options:
   -u, --url <url>         The URL of the Ontotext Refine instance to connect
@@ -27,7 +28,9 @@ Options:
   -n, --name <name>       A name for the Refine project. If not provided, the
                             file name will be used.
   -f, --format <format>   The format of the provided file. The default format
-                            is 'csv'. The allowed values are: csv
+                            is 'csv'. Except 'csv', all other formats are in
+                            experimental state. The allowed values are: csv,
+                            tsv, excel, json, xml
   -c, --configurations <configurations>
                           File containing configurations for the importing
                             process of the dataset. It includes information how

--- a/commands/transform.md
+++ b/commands/transform.md
@@ -29,8 +29,8 @@ Transforms given dataset into different data format.
 Parameters:
       FILE                The file containing the data that should be
                             transformed. It should be a full name with one of
-                            the supported extensions: (csv, tsv, json, txt,
-                            xls, xlsx, js, etc.).
+                            the supported extensions: (csv, tsv, json, xls,
+                            xlsx, etc.).
 
 Options:
   -u, --url <url>         The URL of the Ontotext Refine instance to connect

--- a/commands/transform.md
+++ b/commands/transform.md
@@ -29,13 +29,16 @@ Transforms given dataset into different data format.
 Parameters:
       FILE                The file containing the data that should be
                             transformed. It should be a full name with one of
-                            the supported extensions: (csv).
+                            the supported extensions: (csv, tsv, json, txt,
+                            xls, xlsx, js, etc.).
 
 Options:
   -u, --url <url>         The URL of the Ontotext Refine instance to connect
                             to, e.g. http://localhost:7333.
   -f, --format <format>   The format of the provided file. The default format
-                            is 'csv'. The allowed values are: csv
+                            is 'csv'. Except 'csv', all other formats are in
+                            experimental state. The allowed values are: csv,
+                            tsv, excel, json, xml
   -c, --configurations <configurations>
                           A file with the configurations that should be used
                             for project creation. Ideally it should contain the

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.ontotext</groupId>
     <artifactId>ontorefine-cli</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A command-line interface for execution of operations in Ontotext Refine</description>
@@ -80,19 +80,19 @@
 
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
         <maven.resources.plugin.version>3.3.0</maven.resources.plugin.version>
-        <maven.checkstyle.plugin.version>3.2.0</maven.checkstyle.plugin.version>
-        <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
+        <maven.checkstyle.plugin.version>3.2.1</maven.checkstyle.plugin.version>
+        <maven.surefire.plugin.version>3.0.0-M8</maven.surefire.plugin.version>
         <maven.release.plugin.version>3.0.0-M7</maven.release.plugin.version>
-        <dependency.check.plugin.version>7.4.4</dependency.check.plugin.version>
+        <dependency.check.plugin.version>8.0.2</dependency.check.plugin.version>
         <jacoco.version>0.8.8</jacoco.version>
 
         <ontorefine.client.version>1.8.0</ontorefine.client.version>
-        <picocli.version>4.7.0</picocli.version>
+        <picocli.version>4.7.1</picocli.version>
 
         <slf4j.version>1.7.32</slf4j.version>
-        <jackson.version>2.14.1</jackson.version>
-        <junit.jupiter.version>5.9.1</junit.jupiter.version>
-        <mockito.version>4.11.0</mockito.version>
+        <jackson.version>2.14.2</jackson.version>
+        <junit.jupiter.version>5.9.2</junit.jupiter.version>
+        <mockito.version>5.1.1</mockito.version>
 
         <checkstyle.enabled>true</checkstyle.enabled>
         <skip.dependency.check>false</skip.dependency.check>

--- a/src/main/java/com/ontotext/refine/cli/create/CreateProject.java
+++ b/src/main/java/com/ontotext/refine/cli/create/CreateProject.java
@@ -46,7 +46,7 @@ public class CreateProject extends Process {
       paramLabel = "FILE",
       description = "The file that will be used to create the project."
           + " It should be a full name with one of the supported extensions"
-          + " (csv).") // tsv, , json, txt, xls, xlsx, ods
+          + " (csv, tsv, json, txt, xls, xlsx, js, etc.).")
   private File file;
 
   @Option(
@@ -57,6 +57,7 @@ public class CreateProject extends Process {
   @Option(
       names = {"-f", "--format"},
       description = "The format of the provided file. The default format is '${DEFAULT-VALUE}'."
+          + " Except 'csv', all other formats are in experimental state."
           + " The allowed values are: ${COMPLETION-CANDIDATES}",
       completionCandidates = AllowedInputDataFormats.class,
       defaultValue = "csv")

--- a/src/main/java/com/ontotext/refine/cli/create/CreateProject.java
+++ b/src/main/java/com/ontotext/refine/cli/create/CreateProject.java
@@ -2,8 +2,6 @@ package com.ontotext.refine.cli.create;
 
 import static com.ontotext.refine.cli.project.aliases.ProjectAliasesUtils.assignAliases;
 import static com.ontotext.refine.cli.project.aliases.ProjectAliasesUtils.extractAliases;
-import static com.ontotext.refine.cli.project.configurations.ProjectConfigurationsParser.Configuration.IMPORT_OPTIONS;
-import static com.ontotext.refine.cli.project.configurations.ProjectConfigurationsParser.get;
 import static com.ontotext.refine.cli.utils.PrintUtils.error;
 import static com.ontotext.refine.cli.utils.PrintUtils.info;
 
@@ -118,12 +116,12 @@ public class CreateProject extends Process {
         .name(StringUtils.defaultIfBlank(name, file.getName()))
         .token(getToken());
 
-    if (configurations != null) {
-      get(configurations, IMPORT_OPTIONS).ifPresent(opts -> command.options(opts::toString));
-    }
+    ImportOptionsProcessor.validateAndConsume(
+        configurations, format, opts -> command.options(opts::toString));
 
     return command.build().execute(client);
   }
+
 
   private void handleError(String projectId, RefineClient client, String message)
       throws RefineException {

--- a/src/main/java/com/ontotext/refine/cli/create/CreateProject.java
+++ b/src/main/java/com/ontotext/refine/cli/create/CreateProject.java
@@ -44,7 +44,7 @@ public class CreateProject extends Process {
       paramLabel = "FILE",
       description = "The file that will be used to create the project."
           + " It should be a full name with one of the supported extensions"
-          + " (csv, tsv, json, txt, xls, xlsx, js, etc.).")
+          + " (csv, tsv, json, xls, xlsx, etc.).")
   private File file;
 
   @Option(

--- a/src/main/java/com/ontotext/refine/cli/create/ImportOptionsProcessor.java
+++ b/src/main/java/com/ontotext/refine/cli/create/ImportOptionsProcessor.java
@@ -1,0 +1,68 @@
+package com.ontotext.refine.cli.create;
+
+import static com.ontotext.refine.cli.project.configurations.ProjectConfigurationsParser.Configuration.IMPORT_OPTIONS;
+import static com.ontotext.refine.cli.project.configurations.ProjectConfigurationsParser.get;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.ontotext.refine.cli.validation.ImportOptionsValidator;
+import com.ontotext.refine.client.exceptions.RefineException;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * Contains common convenient logic for parsing, validation and setting of import options for the
+ * project creation process.
+ *
+ * @author Antoniy Kunchev
+ */
+public class ImportOptionsProcessor {
+
+  private ImportOptionsProcessor() {
+    throw new IllegalStateException("Utility class should not be instantiated.");
+  }
+
+  /**
+   * Parses and consumes the import options extracted from the given configuration file. For some
+   * data types, the options will be validated and errors will be thrown in case of invalid
+   * properties.
+   *
+   * @param configurations file containing the import option
+   * @param format of the input data
+   * @param importOptsConsumer for the import options
+   * @throws IOException when there are issues with the parsing of the file or there are validation
+   *                     errors for the options
+   */
+  public static void validateAndConsume(
+      File configurations, InputDataFormat format, Consumer<JsonNode> importOptsConsumer)
+      throws IOException {
+    if (configurations == null) {
+      throwOnJsonOrXml(format);
+      return;
+    }
+
+    Optional<JsonNode> importOpts = get(configurations, IMPORT_OPTIONS);
+    if (!importOpts.isPresent()) {
+      throwOnJsonOrXml(format);
+      return;
+    }
+
+    JsonNode importOptions = importOpts.get();
+    List<String> errors = ImportOptionsValidator.isValid(importOptions, format);
+    if (!errors.isEmpty()) {
+      throw new RefineException(String.join("\n", errors));
+    }
+
+    importOptsConsumer.accept(importOptions);
+  }
+
+  private static void throwOnJsonOrXml(InputDataFormat format) throws RefineException {
+    if (InputDataFormat.JSON.equals(format) || InputDataFormat.XML.equals(format)) {
+      throw new RefineException(
+          "There should be configuration with import options for file format: "
+              + format.toString().toLowerCase());
+    }
+  }
+}

--- a/src/main/java/com/ontotext/refine/cli/create/InputDataFormat.java
+++ b/src/main/java/com/ontotext/refine/cli/create/InputDataFormat.java
@@ -10,7 +10,15 @@ import com.ontotext.refine.client.UploadFormat;
  */
 public enum InputDataFormat {
 
-  CSV(UploadFormat.SEPARATOR_BASED);
+  CSV(UploadFormat.SEPARATOR_BASED),
+
+  TSV(UploadFormat.SEPARATOR_BASED),
+
+  EXCEL(UploadFormat.EXCEL),
+
+  JSON(UploadFormat.JSON),
+
+  XML(UploadFormat.XML);
 
   // TODO: more for the next releases
 

--- a/src/main/java/com/ontotext/refine/cli/transform/Transform.java
+++ b/src/main/java/com/ontotext/refine/cli/transform/Transform.java
@@ -65,12 +65,13 @@ public class Transform extends Process {
       paramLabel = "FILE",
       description = "The file containing the data that should be transformed."
           + " It should be a full name with one of the supported extensions:"
-          + " (csv).")
+          + " (csv, tsv, json, txt, xls, xlsx, js, etc.).")
   private File file;
 
   @Option(
       names = {"-f", "--format"},
       description = "The format of the provided file. The default format is '${DEFAULT-VALUE}'."
+          + " Except 'csv', all other formats are in experimental state."
           + " The allowed values are: ${COMPLETION-CANDIDATES}",
       completionCandidates = AllowedInputDataFormats.class,
       defaultValue = "csv")
@@ -164,7 +165,8 @@ public class Transform extends Process {
   private String createProject(RefineClient client) throws IOException {
     String currentDate = DateTimeFormatter.ISO_LOCAL_DATE.format(LocalDate.now());
     Builder command = RefineCommands
-        .createProject().file(file)
+        .createProject()
+        .file(file)
         .format(format.toUploadFormat())
         .name(format("cli-transform-%s-%s", file.getName(), currentDate))
         .token(getToken());

--- a/src/main/java/com/ontotext/refine/cli/transform/Transform.java
+++ b/src/main/java/com/ontotext/refine/cli/transform/Transform.java
@@ -3,8 +3,6 @@ package com.ontotext.refine.cli.transform;
 import static com.ontotext.refine.cli.operations.OperationsUtil.getOperations;
 import static com.ontotext.refine.cli.project.aliases.ProjectAliasesUtils.assignAliases;
 import static com.ontotext.refine.cli.project.aliases.ProjectAliasesUtils.extractAliases;
-import static com.ontotext.refine.cli.project.configurations.ProjectConfigurationsParser.Configuration.IMPORT_OPTIONS;
-import static com.ontotext.refine.cli.project.configurations.ProjectConfigurationsParser.get;
 import static com.ontotext.refine.cli.utils.ExportUtils.awaitProcessesCompletion;
 import static com.ontotext.refine.cli.utils.PrintUtils.error;
 import static com.ontotext.refine.cli.utils.PrintUtils.info;
@@ -15,6 +13,7 @@ import static java.lang.String.format;
 
 import com.ontotext.refine.cli.Process;
 import com.ontotext.refine.cli.create.AllowedInputDataFormats;
+import com.ontotext.refine.cli.create.ImportOptionsProcessor;
 import com.ontotext.refine.cli.create.InputDataFormat;
 import com.ontotext.refine.cli.export.rdf.AllowedRdfResultFormat;
 import com.ontotext.refine.cli.export.rdf.RdfResultFormats;
@@ -171,9 +170,8 @@ public class Transform extends Process {
         .name(format("cli-transform-%s-%s", file.getName(), currentDate))
         .token(getToken());
 
-    if (configurations != null) {
-      get(configurations, IMPORT_OPTIONS).ifPresent(opts -> command.options(opts::toString));
-    }
+    ImportOptionsProcessor.validateAndConsume(
+        configurations, format, opts -> command.options(opts::toString));
 
     return command.build().execute(client).getProjectId();
   }

--- a/src/main/java/com/ontotext/refine/cli/transform/Transform.java
+++ b/src/main/java/com/ontotext/refine/cli/transform/Transform.java
@@ -64,7 +64,7 @@ public class Transform extends Process {
       paramLabel = "FILE",
       description = "The file containing the data that should be transformed."
           + " It should be a full name with one of the supported extensions:"
-          + " (csv, tsv, json, txt, xls, xlsx, js, etc.).")
+          + " (csv, tsv, json, xls, xlsx, etc.).")
   private File file;
 
   @Option(

--- a/src/main/java/com/ontotext/refine/cli/validation/ImportOptionsValidator.java
+++ b/src/main/java/com/ontotext/refine/cli/validation/ImportOptionsValidator.java
@@ -1,0 +1,62 @@
+package com.ontotext.refine.cli.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.ontotext.refine.cli.create.InputDataFormat;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Contains logic for validation of the import options based on the input data format.
+ *
+ * @author Antoniy Kunchev
+ */
+public class ImportOptionsValidator {
+
+  private ImportOptionsValidator() {
+    throw new IllegalStateException("Utility class should not be instantiated.");
+  }
+
+  /**
+   * Validates the import options for specific format and collects the errors.
+   *
+   * @param importOptions to validate
+   * @param format of the imported data
+   * @return list containing the validation errors. Empty list means valid import options
+   */
+  public static List<String> isValid(JsonNode importOptions, InputDataFormat format) {
+    List<String> errors = new LinkedList<>();
+    switch (format) {
+      case JSON:
+      case XML:
+        containsRecordPath(importOptions, format, errors);
+        return errors;
+      default:
+        return errors;
+    }
+  }
+
+  private static void containsRecordPath(
+      JsonNode importOptions, InputDataFormat format, List<String> errors) {
+    if (importOptions == null || importOptions.isEmpty() || importOptions.isNull()) {
+      errors.add(
+          "Import options configurations are required for files of type: "
+              + format.toString().toLowerCase());
+      return;
+    }
+
+    boolean hasRecordPath = importOptions.isArray()
+        ? hasRecordPath(importOptions.get(0))
+        : hasRecordPath(importOptions);
+
+    if (!hasRecordPath) {
+      errors.add(
+          "The import options should contain property 'recordPath' of type Array, containing set of"
+              + " elements to be used for parsing of the dataset in tabular format.");
+    }
+  }
+
+  private static boolean hasRecordPath(JsonNode importOptions) {
+    JsonNode recordPath = importOptions.get("recordPath");
+    return recordPath != null && recordPath.isArray() && !recordPath.isEmpty();
+  }
+}

--- a/src/test/java/com/ontotext/refine/cli/create/CreateProjectTest.java
+++ b/src/test/java/com/ontotext/refine/cli/create/CreateProjectTest.java
@@ -197,6 +197,64 @@ class CreateProjectTest extends BaseProcessTest {
     }
   }
 
+  @Test
+  @ExpectedSystemExit(ExitCode.SOFTWARE)
+  void shouldFail_missingConfigurationsForXml() {
+    try {
+      URL resource = getClass().getClassLoader().getResource("test-example.xml");
+
+      String uriArg = "-u " + responder.getUri();
+      commandExecutor().accept(args(resource.getPath(), "-n test-xml", "-f xml", uriArg));
+    } finally {
+      String[] errorsArray = consoleErrors().split(System.lineSeparator());
+      String lastLine = errorsArray[errorsArray.length - 1];
+      assertEquals(
+          "There should be configuration with import options for file format: xml",
+          lastLine);
+    }
+  }
+
+  @Test
+  @ExpectedSystemExit(ExitCode.SOFTWARE)
+  void shouldFail_missingImportOptionsInConfiguration() {
+    try {
+      URL resource = getClass().getClassLoader().getResource("test-example.xml");
+      URL configurations = getClass().getClassLoader()
+          .getResource("invalid-configurations/xml-without-import-opts.json");
+
+      String uriArg = "-u " + responder.getUri();
+      String configsArg = "-c " + configurations.getPath();
+      commandExecutor()
+          .accept(args(resource.getPath(), "-n test-xml", "-f xml", configsArg, uriArg));
+    } finally {
+      String[] errorsArray = consoleErrors().split(System.lineSeparator());
+      String lastLine = errorsArray[errorsArray.length - 1];
+      assertEquals("Import options configurations are required for files of type: xml", lastLine);
+    }
+  }
+
+  @Test
+  @ExpectedSystemExit(ExitCode.SOFTWARE)
+  void shouldFail_invalidImportConfigurations() {
+    try {
+      URL resource = getClass().getClassLoader().getResource("test-example.xml");
+      URL importOptsJson = getClass().getClassLoader()
+          .getResource("invalid-configurations/xml-without-recordPath-property.json");
+
+      String uriArg = "-u " + responder.getUri();
+      String importOptsArg = "-c " + importOptsJson.getPath();
+      commandExecutor()
+          .accept(args(resource.getPath(), "-n test-xml", "-f xml", importOptsArg, uriArg));
+    } finally {
+      String[] errorsArray = consoleErrors().split(System.lineSeparator());
+      String lastLine = errorsArray[errorsArray.length - 1];
+      assertEquals(
+          "The import options should contain property 'recordPath' of type Array, containing set of"
+              + " elements to be used for parsing of the dataset in tabular format.",
+          lastLine);
+    }
+  }
+
   private static Map<String, HttpRequestHandler> mockResponses() {
     Map<String, HttpRequestHandler> responses = new HashMap<>(4);
     HandlerContext context = new HandlerContext().setFailCsrfRequest(() -> failCsrfRequest);

--- a/src/test/java/com/ontotext/refine/cli/create/CreateProjectTest.java
+++ b/src/test/java/com/ontotext/refine/cli/create/CreateProjectTest.java
@@ -21,7 +21,6 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.protocol.HttpRequestHandler;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine.ExitCode;
 
@@ -84,13 +83,13 @@ class CreateProjectTest extends BaseProcessTest {
       URL resource = getClass().getClassLoader().getResource("Netherlands_restaurants.csv");
 
       String uriArg = "-u " + responder.getUri();
-      commandExecutor().accept(args(resource.getPath(), "-n Restaurants", "-f tsv", uriArg));
+      commandExecutor().accept(args(resource.getPath(), "-n Restaurants", "-f ods", uriArg));
     } finally {
       String[] errorsArray = consoleErrors().split(System.lineSeparator());
       String lastLine = errorsArray[0];
       assertEquals(
-          "Invalid value for option '--format': expected one of [CSV] (case-insensitive)"
-              + " but was 'tsv'",
+          "Invalid value for option '--format': expected one of [CSV, TSV, EXCEL, JSON, XML]"
+              + " (case-insensitive) but was 'ods'",
           lastLine);
     }
   }
@@ -176,7 +175,6 @@ class CreateProjectTest extends BaseProcessTest {
     }
   }
 
-  @Disabled("Not yet introduced.")
   @Test
   @ExpectedSystemExit(ExitCode.OK)
   void shouldPassSuccessfully_xml() {

--- a/src/test/resources/invalid-configurations/xml-without-import-opts.json
+++ b/src/test/resources/invalid-configurations/xml-without-import-opts.json
@@ -1,0 +1,18 @@
+{
+  "importOptions": [],
+  "operations": [
+    {
+      "op": "core/text-transform",
+      "engineConfig": {
+        "facets": [],
+        "mode": "row-based"
+      },
+      "columnName": "Tests - Test - TestId",
+      "expression": "grel:value.substring(3)",
+      "onError": "keep-original",
+      "repeat": false,
+      "repeatCount": 10,
+      "description": "Text transform on cells in column Tests - Test - TestId using expression grel:value.substring(3)"
+    }
+  ]
+}

--- a/src/test/resources/invalid-configurations/xml-without-recordPath-property.json
+++ b/src/test/resources/invalid-configurations/xml-without-recordPath-property.json
@@ -1,0 +1,34 @@
+{
+  "importOptions": [
+    {
+      "limit": -1,
+      "trimStrings": false,
+      "guessCellValueTypes": false,
+      "storeEmptyStrings": true,
+      "includeFileSources": false,
+      "includeArchiveFileName": false,
+      "disableAutoPreview": false,
+      "projectName": "test-example-xml",
+      "projectTags": [
+        "xml"
+      ],
+      "fileSource": "test-example.xml",
+      "archiveFileName": null
+    }
+  ],
+  "operations": [
+    {
+      "op": "core/text-transform",
+      "engineConfig": {
+        "facets": [],
+        "mode": "row-based"
+      },
+      "columnName": "Tests - Test - TestId",
+      "expression": "grel:value.substring(3)",
+      "onError": "keep-original",
+      "repeat": false,
+      "repeatCount": 10,
+      "description": "Text transform on cells in column Tests - Test - TestId using expression grel:value.substring(3)"
+    }
+  ]
+}


### PR DESCRIPTION
Extends the allowed upload formats for create and transform commands

- Extended the set of allowed upload formats for `create project` and
`transform` commands. Now they will consume `tsv`, `excel`, `xml`,
`json`, etc., in addition to the already available `csv`.

  Although the added formats are supported fully in the Refine, they are
introduced in experimental state for the CLI as they aren't extensively
tested. There could be some issues with them, which will be addressed in
the next versions of the project.

- Updated the versions of the third party dependencies to the latest
available.

- Prepared the project for a release of a new patch version `1.2.1`.

---
Adds "temporary" validation for import options of XML and JSON files

- Added validation for the import options configurations for the XML and
JSON types of files. For them, it is required the options to contain
`recordPath` property, which defines from where and how the data will be
parsed into tabular form.

  We need this logic, because there is a bug in the OpenRefine that
ignores the error that above property is missing and returns OK
response, without actually doing anything in the background.

  The validation that was introduced will check for the existence of the
property and the actual value(s) in it. If something is wrong with the
configurations, the user will receive an error message, instead of
response for successful operation.

---
Fixes the descriptions of the arguments in some of the commands

- Fixed the descriptions of some of the commands arguments in order to
better reflect the latest state of the CLI changes.